### PR TITLE
Caching in XOZ v0.

### DIFF
--- a/mountpoint-s3/scripts/fs_cache_xoz_bench.sh
+++ b/mountpoint-s3/scripts/fs_cache_xoz_bench.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+set -e
+
+if ! command -v fio &> /dev/null; then
+  echo "fio must be installed to run this benchmark"
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET_NAME}" ]]; then
+  echo "Set S3_BUCKET_NAME to run this benchmark"
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET_TEST_PREFIX}" ]]; then
+  echo "Set S3_BUCKET_TEST_PREFIX to run this benchmark"
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET_BENCH_FILE}" ]]; then
+  echo "Set S3_BUCKET_BENCH_FILE to run this benchmark"
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET_SMALL_BENCH_FILE}" ]]; then
+  echo "Set S3_BUCKET_SMALL_BENCH_FILE to run this benchmark"
+  exit 1
+fi
+
+if [[ -n "${S3_JOB_NAME_FILTER}" ]]; then
+  echo "Will only run fio jobs which match $S3_JOB_NAME_FILTER"
+fi
+
+optional_args=""
+
+if [[ -n "${S3_ENDPOINT_URL}" ]]; then
+  optional_args+="--endpoint-url=${S3_ENDPOINT_URL}"
+fi
+
+base_dir=$(dirname "$0")
+project_dir="${base_dir}/../.."
+cd ${project_dir}
+
+results_dir=results
+runtime_seconds=30
+startdelay_seconds=30
+iterations=10
+
+rm -rf ${results_dir}
+mkdir -p ${results_dir}
+
+run_fio_job() {
+  job_file=$1
+  bench_file=$2
+  mount_dir=$3
+  log_dir=$4
+
+  job_name=$(basename "${job_file}")
+  job_name="${job_name%.*}"
+
+
+  echo -n "Running job ${job_name} for ${iterations} iterations... "
+
+  for i in $(seq 1 $iterations);
+  do
+    echo -n "${i};"
+    # we know each fio job will be running for exactly 1 minute from the job definitions.
+    # there must be something wrong if it takes longer than that.
+    set +e
+    timeout 300s fio --thread \
+      --output=${results_dir}/${job_name}_iter${i}.json \
+      --output-format=json \
+      --directory=${mount_dir} \
+      --filename=${bench_file} \
+      --eta=never \
+      ${job_file}
+    job_status=$?
+    set -e
+    if [ $job_status -ne 0 ]; then
+      tail -1000 ${log_dir}/mountpoint-s3-*
+      echo "Job ${job_name} failed with exit code ${job_status}"
+      exit 1
+    fi
+  done
+  echo "done"
+
+  # combine the results and find an average value
+  jq -n 'reduce inputs.jobs[] as $job (null; .name = $job.jobname | .len += 1 | .value += (if ($job."job options".rw == "read")
+      then $job.read.bw / 1024
+      elif ($job."job options".rw == "randread") then $job.read.bw / 1024
+      elif ($job."job options".rw == "randwrite") then $job.write.bw / 1024
+      else $job.write.bw / 1024 end)) | {name: .name, value: (.value / .len), unit: "MiB/s"}' ${results_dir}/${job_name}_iter*.json | tee ${results_dir}/${job_name}_parsed.json
+}
+
+should_run_job() {
+    job_file=$1
+    if [[ -n "${S3_JOB_NAME_FILTER}" ]]; then
+      if [[ "${job_file}" == *"${S3_JOB_NAME_FILTER}"* ]]; then
+        # job name matches filter
+        return 0
+      else
+        # job name does not match filter
+        return 1
+      fi
+    fi
+}
+
+cache_benchmark () {
+  jobs_dir=mountpoint-s3/scripts/fio/read
+
+  local_storage=/tmp
+
+  for job_file in "${jobs_dir}"/*.fio; do
+
+    if ! should_run_job "${job_file}"; then
+      echo "Skipping job ${job_file} because it does not match ${S3_JOB_NAME_FILTER}"
+      continue
+    fi
+
+    mount_dir=$(mktemp -d /tmp/fio-XXXXXXXXXXXX)
+
+    job_name=$(basename "${job_file}")
+    job_name="${job_name%.*}"
+    log_dir=logs/${job_name}
+
+    # cleanup mount directory and log directory
+    cleanup() {
+      echo "cache_benchmark:cleanup"
+      # unmount file system only if it is mounted
+      ! mountpoint -q ${mount_dir} || sudo umount ${mount_dir}
+      rm -rf ${mount_dir}
+      rm -rf ${log_dir}
+    }
+
+    # trap cleanup on exit
+    trap 'cleanup' EXIT
+
+    rm -rf ${log_dir}
+    mkdir -p ${log_dir}
+
+    # mount file system
+    set +e
+    cargo run --quiet --release -- \
+      ${S3_BUCKET_NAME} ${mount_dir} \
+      --debug \
+      --allow-delete \
+      --cache-xoz=mp-iad-cache--use1-az6--x-s3 \
+      --cache-xoz-block-size=16 \
+      --log-directory=${log_dir} \
+      --prefix=${S3_BUCKET_TEST_PREFIX} \
+      --part-size=16777216 \
+      ${optional_args}
+    mount_status=$?
+    set -e
+    if [ $mount_status -ne 0 ]; then
+      echo "Failed to mount file system"
+      exit 1
+    fi
+
+    # set bench file
+    bench_file=${S3_BUCKET_BENCH_FILE}
+    # run against small file if the job file ends with small.fio
+    if [[ $job_file == *small.fio ]]; then
+      bench_file=${S3_BUCKET_SMALL_BENCH_FILE}
+    fi
+
+    # run the benchmark
+    run_fio_job $job_file $bench_file $mount_dir $log_dir
+
+    cleanup
+  done
+}
+
+cache_benchmark
+
+# combine all bench results into one json file
+jq -n '[inputs]' ${results_dir}/*_parsed.json | tee ${results_dir}/output.json

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -5,7 +5,6 @@ use std::num::NonZeroUsize;
 use std::os::fd::AsRawFd;
 use std::os::unix::prelude::FromRawFd;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context as _};
@@ -759,15 +758,27 @@ where
     }
 
     if let Some(xoz_bucket_name) = args.cache_xoz {
-        let client = Arc::new(client);
-        let cache = XozDataCache::new(&xoz_bucket_name, client.clone());
+        // When using the same CRT client, it was hanging, see https://t.corp.amazon.com/D132039029/communication.
+        // So we create a new client for the xoz cache.
+        let new_args = CliArgs {
+            bucket_name: xoz_bucket_name.clone(),
+            storage_class: None,
+            sse: None,
+            sse_kms_key_id: None,
+            cache: None,
+            cache_xoz: None, // nothing is going to need this value anymore
+            ..args
+        };
+        let (xoz_client, _runtime, _personality) =
+            create_s3_client(&new_args).expect("could not create s3 client for xoz cache");
+        let cache = XozDataCache::new(&xoz_bucket_name, xoz_client);
 
         let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
         let fuse_session = create_filesystem(
-            client.clone(),
+            client,
             prefetcher,
             &args.bucket_name,
-            &args.prefix.unwrap_or_default(),
+            &new_args.prefix.unwrap_or_default(),
             filesystem_config,
             fuse_config,
             &bucket_description,

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -263,12 +263,21 @@ pub struct CliArgs {
 
     #[clap(
         long,
-        help = "Enable caching of object metadata and content to the specified xoz bucket (same region only)",
+        help = "Enable caching of object content to the specified xoz bucket (same region only)",
         help_heading = CACHING_OPTIONS_HEADER,
         value_name = "BUCKET",
         value_parser = parse_bucket_name,
     )]
     pub cache_xoz: Option<String>,
+
+    #[clap(
+        long,
+        help = "When caching to xoz, how big each cache block should be in MiB",
+        help_heading = CACHING_OPTIONS_HEADER,
+        value_name = "MiB",
+        requires = "cache_xoz"
+    )]
+    pub cache_xoz_block_size: Option<u64>,
 
     #[clap(
         long,
@@ -771,7 +780,7 @@ where
         };
         let (xoz_client, _runtime, _personality) =
             create_s3_client(&new_args).expect("could not create s3 client for xoz cache");
-        let cache = XozDataCache::new(&xoz_bucket_name, xoz_client);
+        let cache = XozDataCache::new(&xoz_bucket_name, xoz_client, new_args.cache_xoz_block_size);
 
         let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
         let fuse_session = create_filesystem(

--- a/mountpoint-s3/src/cli.rs
+++ b/mountpoint-s3/src/cli.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroUsize;
 use std::os::fd::AsRawFd;
 use std::os::unix::prelude::FromRawFd;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context as _};
@@ -26,7 +27,7 @@ use nix::unistd::ForkResult;
 use regex::Regex;
 
 use crate::build_info;
-use crate::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig, ManagedCacheDir};
+use crate::data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig, ManagedCacheDir, XozDataCache};
 use crate::fs::{CacheConfig, S3FilesystemConfig, ServerSideEncryption, TimeToLive};
 use crate::fuse::session::FuseSession;
 use crate::fuse::S3FuseFilesystem;
@@ -260,6 +261,15 @@ pub struct CliArgs {
         requires = "cache",
     )]
     pub max_cache_size: Option<u64>,
+
+    #[clap(
+        long,
+        help = "Enable caching of object metadata and content to the specified xoz bucket (same region only)",
+        help_heading = CACHING_OPTIONS_HEADER,
+        value_name = "BUCKET",
+        value_parser = parse_bucket_name,
+    )]
+    pub cache_xoz: Option<String>,
 
     #[clap(
         long,
@@ -726,7 +736,9 @@ where
         if let Some(cache_config) = cache_config {
             let managed_cache_dir =
                 ManagedCacheDir::new_from_parent(path).context("failed to create cache directory")?;
+
             let cache = DiskDataCache::new(managed_cache_dir.as_path_buf(), cache_config);
+
             let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
             let mut fuse_session = create_filesystem(
                 client,
@@ -745,6 +757,24 @@ where
             return Ok(fuse_session);
         }
     }
+
+    if let Some(xoz_bucket_name) = args.cache_xoz {
+        let client = Arc::new(client);
+        let cache = XozDataCache::new(&xoz_bucket_name, client.clone());
+
+        let prefetcher = caching_prefetch(cache, runtime, prefetcher_config);
+        let fuse_session = create_filesystem(
+            client.clone(),
+            prefetcher,
+            &args.bucket_name,
+            &args.prefix.unwrap_or_default(),
+            filesystem_config,
+            fuse_config,
+            &bucket_description,
+        )?;
+
+        return Ok(fuse_session);
+    };
 
     let prefetcher = default_prefetch(runtime, prefetcher_config);
     create_filesystem(

--- a/mountpoint-s3/src/data_cache.rs
+++ b/mountpoint-s3/src/data_cache.rs
@@ -7,6 +7,7 @@
 mod cache_directory;
 mod disk_data_cache;
 mod in_memory_data_cache;
+mod xoz_data_cache;
 
 use thiserror::Error;
 
@@ -14,6 +15,7 @@ pub use crate::checksums::ChecksummedBytes;
 pub use crate::data_cache::cache_directory::ManagedCacheDir;
 pub use crate::data_cache::disk_data_cache::{CacheLimit, DiskDataCache, DiskDataCacheConfig};
 pub use crate::data_cache::in_memory_data_cache::InMemoryDataCache;
+pub use crate::data_cache::xoz_data_cache::XozDataCache;
 
 use crate::object::ObjectId;
 

--- a/mountpoint-s3/src/data_cache/xoz_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/xoz_data_cache.rs
@@ -14,15 +14,17 @@ const CACHE_VERSION: &str = "V1";
 pub struct XozDataCache<Client: ObjectClient> {
     bucket_name: String,
     client: Client,
+    block_size: u64,
 }
 impl<Client> XozDataCache<Client>
 where
     Client: ObjectClient + Send + Sync + 'static,
 {
-    pub fn new(bucket_name: &str, client: Client) -> Self {
+    pub fn new(bucket_name: &str, client: Client, block_size: Option<u64>) -> Self {
         Self {
             client,
             bucket_name: bucket_name.to_owned(),
+            block_size: block_size.unwrap_or(1) * 1024 * 1024,
         }
     }
 
@@ -104,7 +106,7 @@ where
     }
 
     fn block_size(&self) -> u64 {
-        1024 * 1024
+        self.block_size
     }
 }
 

--- a/mountpoint-s3/src/data_cache/xoz_data_cache.rs
+++ b/mountpoint-s3/src/data_cache/xoz_data_cache.rs
@@ -1,0 +1,126 @@
+use crate::object::ObjectId;
+
+use super::{BlockIndex, ChecksummedBytes, DataCache, DataCacheResult};
+
+use bytes::Bytes;
+use futures::{pin_mut, StreamExt};
+use mountpoint_s3_client::types::PutObjectParams;
+use mountpoint_s3_client::{ObjectClient, PutObjectRequest};
+use sha2::{Digest, Sha256};
+use tracing::{warn, Instrument};
+
+const CACHE_VERSION: &str = "V1";
+
+pub struct XozDataCache<Client: ObjectClient> {
+    bucket_name: String,
+    client: Client,
+}
+impl<Client> XozDataCache<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    pub fn new(bucket_name: &str, client: Client) -> Self {
+        Self {
+            client,
+            bucket_name: bucket_name.to_owned(),
+        }
+    }
+
+    async fn get_block_xoz(&self, object_key: String) -> DataCacheResult<Option<ChecksummedBytes>> {
+        // TODO: is this the right thing in terms of a range? this is not causing any HEAD request so it might be
+        let result = match self.client.get_object(&self.bucket_name, &object_key, None, None).await {
+            Ok(ok_result) => ok_result,
+            Err(_e) => {
+                //TODO: assuming that key does not exists but it could be something else, so we will need to do something smarter here
+                return DataCacheResult::Ok(None);
+            }
+        };
+
+        pin_mut!(result);
+
+        let mut buffer = ChecksummedBytes::default();
+        loop {
+            warn!("get_block_xoz {}", object_key);
+            match result.next().await {
+                Some(Ok((_offset, body))) => {
+                    // TODO: check offset expectation
+                    let body: Bytes = body.into();
+                    buffer.extend(body.into()).expect("could not extend buffer");
+                }
+                Some(Err(_e)) => {
+                    // TODO: what should we do here? anything better?
+                    return DataCacheResult::Ok(None);
+                }
+                None => {
+                    break;
+                }
+            }
+        }
+
+        DataCacheResult::Ok(Some(buffer))
+    }
+
+    async fn put_block_xoz(&self, object_key: String, bytes: ChecksummedBytes) -> DataCacheResult<()> {
+        warn!("put_block_xoz {}", object_key);
+        // TODO: handle errors in a better way than just expects
+        let params = PutObjectParams::new();
+        let mut req = self
+            .client
+            .put_object(&self.bucket_name, &object_key, &params)
+            .in_current_span()
+            .await
+            .expect("could not create req");
+        let (data, _crc) = bytes.into_inner().expect("could not unpack checksummed bytes");
+        req.write(&data).await.expect("unable to write");
+        req.complete().await.expect("unable to complete upload");
+
+        DataCacheResult::Ok(())
+    }
+}
+impl<Client> DataCache for XozDataCache<Client>
+where
+    Client: ObjectClient + Send + Sync + 'static,
+{
+    fn get_block(
+        &self,
+        cache_key: &ObjectId,
+        block_idx: BlockIndex,
+        _block_offset: u64, // TODO: should we use this?
+    ) -> DataCacheResult<Option<ChecksummedBytes>> {
+        let object_key = object_key(&cache_key, block_idx);
+
+        return futures::executor::block_on(self.get_block_xoz(object_key));
+    }
+
+    fn put_block(
+        &self,
+        cache_key: ObjectId,
+        block_idx: BlockIndex,
+        _block_offset: u64,
+        bytes: ChecksummedBytes,
+    ) -> DataCacheResult<()> {
+        let object_key = object_key(&cache_key, block_idx);
+        return futures::executor::block_on(self.put_block_xoz(object_key, bytes));
+    }
+
+    fn block_size(&self) -> u64 {
+        1024 * 1024
+    }
+}
+
+/// Hash the cache key using its fields as well as the [CACHE_VERSION].
+fn hash_cache_key_raw(cache_key: &ObjectId) -> [u8; 32] {
+    let s3_key = cache_key.key();
+    let etag = cache_key.etag();
+
+    let mut hasher = Sha256::new();
+    hasher.update(CACHE_VERSION.as_bytes());
+    hasher.update(s3_key);
+    hasher.update(etag.as_str());
+    hasher.finalize().into()
+}
+
+fn object_key(cache_key: &ObjectId, block_idx: BlockIndex) -> String {
+    let hashed_cache_key = hex::encode(hash_cache_key_raw(cache_key));
+    format!("{}/{:010}", hashed_cache_key, block_idx)
+}


### PR DESCRIPTION
Caching in XOZ v0.

```
mount-s3 \
--cache-xoz mp-iad-cache--use1-az6--x-s3 \
--cache-xoz-block-size=1 \
--allow-overwrite \
--profile default \
--region us-east-1 \
--metadata-ttl indefinite \
-l ~/mnt-logs \
-d --debug-crt \
mp-arn ~/mnt
```

## Description of change

Benchmarking (throughput) results from an IAD instance in the same zone as the XOZ bucket.

```
# disk caching
[
  {
    "name": "sequential_read_small_file",
    "value": 1862.91904296875,
    "unit": "MiB/s"
  }
]
# xoz caching
[
  {
    "name": "sequential_read_small_file",
    "value": 148.47177734375,
    "unit": "MiB/s"
  }
]
# no caching
[
  {
    "name": "sequential_read_small_file",
    "value": 62.69189453125,
    "unit": "MiB/s"
  }
]
```

<!-- Please describe your contribution here. What and why? -->

Relevant issues: <!-- Please add issue numbers. -->

## Does this change impact existing behavior?

<!-- Please confirm there's no breaking change, or call our any behavior changes you think are necessary. -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
